### PR TITLE
hotfix to support double-digits in cron time disambiguation

### DIFF
--- a/write_cron.py
+++ b/write_cron.py
@@ -29,7 +29,7 @@ def create_job(cmd):
             job.hour.every(get_x(time))
         elif fnmatch(time, 'every ? days'):
             job.day.every(get_x(time))
-        elif fnmatch(time, '? ? ? ? ?'):
+        elif fnmatch(time, '* * * * *'):
             job.setall(time)
         else:
             raise InvalidTimeError


### PR DESCRIPTION
I actually tested it this time lol.